### PR TITLE
refactor(ide): Use server:close() instead of server:stop()

### DIFF
--- a/lua/gemini/ideMcpServer.lua
+++ b/lua/gemini/ideMcpServer.lua
@@ -128,11 +128,7 @@ function IdeMcpServer:close()
   self.server:close()
 end
 
---- Stops the TCP server and closes all active client connections.
---- This is an alias for the `close` method, providing a more intuitive name for shutting down the server.
-function IdeMcpServer:stop()
-  self:close()
-end
+
 
 -------------------------------------------------------------------------------
 -- Public Methods (IdeMcpClient)

--- a/lua/gemini/init.lua
+++ b/lua/gemini/init.lua
@@ -202,9 +202,7 @@ function M.setup(opts)
   vim.api.nvim_create_autocmd('VimLeave', {
     pattern = '*',
     callback = function()
-      log.info('Stopping MCP server')
-      if not server.stop then log.info('Calling wrong method') end
-      server:stop()
+      if server then server:close() end
     end,
   })
 


### PR DESCRIPTION
This commit refactors the MCP server to use the `close` method directly instead of the `stop` alias.
The `stop` method has been removed, and the `VimLeave` autocommand now calls `server:close()`.
This simplifies the code and removes the indirection.

Fixes #6