### PR TITLE
feat(diff): Add vim-style :wq/:q to accept/reject diffs

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ https://github.com/user-attachments/assets/48324de2-1c7c-4a00-966a-23836aecd29e
 
 ## Features
 
-*   ✅ **Diff View:** Compare your local file with AI suggestions and accept/reject changes seamlessly
+*   ✅ **Diff Control:** Auto diff views, accept or reject suggestions directly from vim using `:wq` or `:q`.
 *   ✅ **CLI Agent:** Dedicated terminal session for interacting with AI agents
 *   ✅ **Multi-Agent Support:** Run both `gemini` and `qwen-code` agents simultaneously 
 *   ✅ **Tab-based Switching:** Effortlessly switch between AI terminals with `<Tab>`
@@ -76,6 +76,22 @@ The following options are available in the `setup` function:
     *   The plugin checks if the agent is installed in the system PATH and only enables it if found.
     *   If you want to use only one agent, you can set it as a single command string, e.g., `cmd = "gemini"`.
 *   `win`: This option configures the window for the Gemini sidebar. It respects the `snacks.win` options from the [`folke/snacks.nvim`](https://github.com/folke/snacks.nvim) library. For more information on the available options, please refer to the [snacks.win documentation](https://github.com/folke/snacks.nvim/blob/main/docs/win.md).
+
+### Accepting and Rejecting Diffs
+
+When a diff view is presented, you have multiple ways to handle the suggested changes:
+
+*   **Vim-style Commands:**
+    *   `:w` or `:wq`: Write the buffer to accept the changes.
+    *   `:q` or `:q!`: Quit the buffer without writing to reject the changes.
+    This behavior is inspired by `vim.pack`.
+
+*   **Plugin Commands:**
+    *   `:GeminiAccept`: Accept the changes.
+    *   `:GeminiReject`: Reject the changes.
+
+These commands provide flexibility in how you manage the diffs, allowing you to use the method you find most comfortable.
+
 
 ### Sidebar Presets
 

--- a/lua/gemini/ideDiffManager.lua
+++ b/lua/gemini/ideDiffManager.lua
@@ -169,6 +169,15 @@ local function closeView(filePath)
     content = table.concat(lines, '\n')
   end
 
+  -- delete the buffers
+  if view.originalBuf and vim.api.nvim_buf_is_valid(view.originalBuf) then
+    vim.api.nvim_buf_delete(view.originalBuf, { force = true })
+  end
+  if view.newBuf and vim.api.nvim_buf_is_valid(view.newBuf) then
+    vim.api.nvim_buf_delete(view.newBuf, { force = true })
+  end
+
+  -- close the windows
   for _, winId in ipairs(view.winIds) do
     if vim.api.nvim_win_is_valid(winId) then
       vim.api.nvim_win_close(winId, true)
@@ -240,6 +249,8 @@ function manager.getFilePathFromWindowID(winId)
   print('Not a Gemini diff buffer')
   return nil
 end
+
+function manager.getView(filePath) return views[filePath] end
 
 ---
 -- Sets up the user commands for interacting with the diff view.

--- a/tests/ideDiffManager_spec.lua
+++ b/tests/ideDiffManager_spec.lua
@@ -85,12 +85,15 @@ describe('ideDiffManager', function()
     )
   end)
 
-it('should close the diff view', function()
+it('should close the diff view and clean up views table', function()
     -- 1. Setup: Open a diff view first
     local tempFile = vim.fn.tempname()
     vim.fn.writefile({ 'line 1' }, tempFile)
     local newContent = 'line 1 changed'
     diffManager.open(tempFile, newContent)
+
+    -- Assert that the view exists before closing
+    assert.is_not_nil(diffManager.getView(tempFile))
 
     diffManager.close(tempFile)
 
@@ -100,6 +103,8 @@ it('should close the diff view', function()
       #vim.api.nvim_list_tabpages(),
       'Should have only one tab after close'
     )
+    -- Assert that the view is cleaned up
+    assert.is_nil(diffManager.getView(tempFile))
   end)
 
   it("should accept the diff and call onClose with 'accepted'", function()


### PR DESCRIPTION
This pull request introduces a new way to accept or reject diffs in the diff view, using vim-style commands.

- Use `:wq` to accept the changes.
- Use `:q` to reject the changes.

This provides a more intuitive and familiar workflow for many Vim users, similar to how `vim.pack` works.

The `:GeminiAccept` and `:GeminiReject` commands are still available.

Closes #12