### PR TITLE
feat: add health check functionality

### DIFF
--- a/lua/gemini/health.lua
+++ b/lua/gemini/health.lua
@@ -1,0 +1,53 @@
+local health = vim.health
+local M = {}
+
+M.serverStatus = function()
+  local has_gemini, gemini = pcall(require, 'gemini')
+  if not has_gemini or not gemini or not gemini.getServerStatus then
+    health.error('nvim-gemini-companion plugin not loaded')
+    return
+  end
+  local serverStatus = gemini.getServerStatus()
+  if not serverStatus.initialized then
+    health.error('MCP server not initialized')
+    return
+  end
+  if not serverStatus.port or serverStatus.port == 0 then
+    health.error('MCP server not listening on a port')
+    return
+  end
+  health.ok('MCP server is initialized')
+  health.ok('MCP server running on port ' .. tostring(serverStatus.port))
+  health.ok('Workspace: ' .. serverStatus.workspace)
+end
+
+M.check = function()
+  health.start('nvim-gemini-companion health check')
+
+  -- Check if gemini CLI is available
+  if vim.fn.executable('gemini') == 1 then
+    health.ok('Gemini CLI is installed')
+  else
+    health.warn('Gemini CLI is not installed or not in PATH')
+  end
+
+  -- Check if qwen CLI is available
+  if vim.fn.executable('qwen') == 1 then
+    health.ok('Qwen CLI is installed')
+  else
+    health.warn('Qwen CLI is not installed or not in PATH')
+  end
+
+  -- Check if plenary.nvim is available
+  local hasPlenary, _ = pcall(require, 'plenary')
+  if hasPlenary then
+    health.ok('plenary.nvim is installed')
+  else
+    health.warn('plenary.nvim is not installed (required dependency)')
+  end
+
+  -- Check if mcp-server is initialized
+  M.serverStatus()
+end
+
+return M

--- a/lua/gemini/init.lua
+++ b/lua/gemini/init.lua
@@ -300,4 +300,20 @@ function M.disableAutoread()
   log.info('Autoread disabled')
 end
 
+--- Get server status for health check
+function M.getServerStatus()
+  local status = {
+    initialized = initialized,
+    port = nil,
+    workspace = vim.fn.getcwd(),
+  }
+
+  if server and server.server then
+    local sockname = server.server:getsockname()
+    if sockname then status.port = sockname.port end
+  end
+
+  return status
+end
+
 return M


### PR DESCRIPTION
- Add health.lua module implementing Neovim's health check API
- Add getServerStatus() function to main module to report server status
- Health check reports:
  - MCP server initialization status
  - MCP server port number
  - Workspace directory
  - Availability of gemini and qwen CLIs in system PATH
  - plenary.nvim dependency status
- Users can run :checkhealth gemini to check plugin health