### PR TITLE
feat(sidebar): Enhance terminal switching with active-only navigation

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,35 @@ Install with your favorite plugin manager:
 - `:GeminiSend` - Send selected text to AI (use in visual mode)
 - `:GeminiSendLineDiagnostic` - Send line diagnostics to AI
 - `:GeminiSendFileDiagnostic` - Send file diagnostics to AI
+- `:GeminiSwitchSidebarStyle` - Switch the appearance/style of the sidebar
+
+### Sidebar Terminal Switching
+When multiple commands are configured (e.g., both `gemini` and `qwen`), you can switch between active sidebar terminals using default key mappings:
+
+- `<M-]>` - Switch to the next active terminal (Alt + ])
+- `<M-[>` - Switch to the previous active terminal (Alt + [)
+
+To customize these key bindings, you can override the default mappings in your setup function:
+
+```lua
+require("gemini").setup({
+  cmds = { "gemini", "qwen" },
+  -- Override default key mappings
+  on_buf = function(buf)
+    -- Add your own custom mappings
+    vim.api.nvim_buf_set_keymap(buf, 't', '<Tab>', 
+      '<Cmd>lua require("gemini.ideSidebar").switchSidebar()<CR>', 
+      { noremap = true, silent = true }
+    )
+    vim.api.nvim_buf_set_keymap(buf, 't', '<S-Tab>', 
+      '<Cmd>lua require("gemini.ideSidebar").switchSidebar("prev")<CR>', 
+      { noremap = true, silent = true }
+    )
+  end
+})
+```
+
+**Note:** Be aware that `<Tab>` and `<S-Tab>` may already be mapped to other functionality by the Gemini/Qwen CLIs themselves, so using these keys for terminal switching might interfere with their built-in features. Consider using alternative key bindings such as `<C-Tab>` and `<C-S-Tab>` or the default Alt-based mappings instead.
 
 ### Diff Management
 When AI suggests changes, you can:

--- a/lua/gemini/announcements/v0.7.1_release.md
+++ b/lua/gemini/announcements/v0.7.1_release.md
@@ -1,0 +1,36 @@
+# v0.7.1 Release Announcement
+
+## 🎉 Improvements
+
+### Enhanced Sidebar Terminal Switching
+The sidebar terminal switching functionality has been improved with more reliable behavior:
+- Only switches between *active* terminals (no more spawning new processes when switching)
+- Supports forward and backward navigation between active terminals
+- Better safety checks to prevent errors when few terminals are active
+
+## ⚠️ Breaking Changes
+
+### Behavior Change
+- **Old**: `<Tab>` would hide current terminal and spawn/show the next one in the list
+- **New**: `<M-]>` (Alt+]) and `<M-[>` (Alt+[) only switch between already *active* terminals without spawning new processes
+
+### Function Renamed
+- **Old**: `require('gemini.ideSidebar').switchTerms()`
+- **New**: `require('gemini.ideSidebar').switchSidebar()`
+
+## 🔄 What You Need to Do
+
+### If You're Using the Function Manually
+If you were calling `switchTerms()` manually in your configuration, update your code:
+
+```lua
+-- Change from this:
+require('gemini.ideSidebar').switchTerms()
+
+-- To this:
+require('gemini.ideSidebar').switchSidebar([direction])
+-- where direction can be 'next' (default) or 'prev'
+```
+
+### For Key Binding Customization
+If you want to customize the terminal switching key bindings, see the updated README documentation which shows how to override the default Alt-based mappings.


### PR DESCRIPTION
This change enhances the `GeminiSwitchToCli` command to provide a better experience when spawning and switching between terminal windows.

The main motivations for this change are:
-   Improved `GeminiSwitchToCli` command for a more intuitive spawning experience.
-   Ability to switch between active terminals only, which is useful when you have multiple CLIs configured (e.g., 'gemini', 'qwen', 'orchat') and only want to cycle through a subset of them.
-   Convenient forward and backward navigation between active terminals.