### PR TITLE
[Bug Fix] Quit visual mode to send selected text.

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,10 +30,8 @@ Install with your favorite plugin manager:
   keys = {
     { "<leader>gg", "<cmd>GeminiToggle<cr>", desc = "Toggle Gemini sidebar" },
     { "<leader>gc", "<cmd>GeminiSwitchToCli<cr>", desc = "Spawn or switch to AI session" },
-    { "<leader>gS", function() 
-        vim.cmd('normal! gv')
-        vim.cmd("'<,'>GeminiSend")
-      end, mode = { 'x' }, desc = 'Send selection to AI' },
+    { '<leader>gS', '<cmd>GeminiSend<cr>', mode = { 'x' }, desc = 'Send selection to Gemini' },
+
   }
 }
 ```

--- a/lua/gemini/ideSidebar.lua
+++ b/lua/gemini/ideSidebar.lua
@@ -196,6 +196,9 @@ end
 -- @param cmdOpts table Command options containing args for additional text
 -- @return nil
 function ideSidebar.sendSelectedText(cmdOpts)
+  -- Exit visual mode if we are in it, to ensure marks are updated and we are in normal mode
+  if vim.fn.mode():find('[vV\22]') then vim.cmd('normal! \27') end
+
   local text = cmdOpts.args or ''
   local selectedText = ''
 


### PR DESCRIPTION
The recommended keymap in the readme for sending selected text didn't work for me that it didn't quit select/visual mode. However \27 works and I think it's preferred behavior in send selected text to always check the mode so it doesn't jump the curosr to the gemini cli panel in select/visual mode. This would also match the behavior in other popular Coding assistant plugins such as https://github.com/coder/claudecode.nvim.